### PR TITLE
Add RequestCookies class to collect HTTP cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0 under development
 
 - Enh #10: Add `yiisoft/middleware-dispatcher` event listener to keep `Request` always available (@xepozz)
-- Add `Yiisoft/RequestProvider/RequestCookies` request cookie collection object (@hacan359)
+- Add `RequestCookies` class that provides convenient access to request cookies (@hacan359)
 
 ## 1.0.0 March 02, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0 under development
 
 - Enh #10: Add `yiisoft/middleware-dispatcher` event listener to keep `Request` always available (@xepozz)
+- Add `Yiisoft/RequestProvider/RequestCookies` request cookie collection object (@hacan359)
 
 ## 1.0.0 March 02, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.1.0 under development
 
 - Enh #10: Add `yiisoft/middleware-dispatcher` event listener to keep `Request` always available (@xepozz)
-- Add `RequestCookies` class that provides convenient access to request cookies (@hacan359)
+- New #11: Add `RequestCookies` class that provides convenient access to request cookies (@hacan359)
 
 ## 1.0.0 March 02, 2024
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ class MyClass
   
   public function go(): void
   {
-    $this->cookies->has(...);
-    $this->cookies->get(...)
+    $this->cookies->has('foo');
+    $this->cookies->get('bar');
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ final class MyService
 }
 ```
 
+### Request cookies collection
+
+You can work with cookie request from any place in you project. Add in config you app in middleware block
+
+```php
+class MyClass {
+  public function __construct(
+    private \Yiisoft\RequestProvider\RequestCookies $cookies
+  ) {}
+  
+  public function go(): void {
+    $this->cookies->has(...);
+    $this->cookies->get(...)
+  }
+}
+```
+
 ## Documentation
 
 - [Internals](docs/internals.md)

--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ final class MyService
 
 ### Request cookies collection
 
-You can work with cookie request from any place in you project. Add in config you app in middleware block
+You can work with cookies like the following:
 
 ```php
-class MyClass {
+class MyClass
+{
   public function __construct(
     private \Yiisoft\RequestProvider\RequestCookies $cookies
   ) {}
   
-  public function go(): void {
+  public function go(): void
+  {
     $this->cookies->has(...);
     $this->cookies->get(...)
   }

--- a/src/RequestCookies.php
+++ b/src/RequestCookies.php
@@ -26,6 +26,6 @@ final class RequestCookies
 
     public function has(string $name): bool
     {
-        return isset($this->cookies[$name]);
+        return array_key_exists($name, $this->cookies);
     }
 }

--- a/src/RequestCookies.php
+++ b/src/RequestCookies.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\RequestProvider;
+
+final class RequestCookies
+{
+    /**
+     * @var array The cookies in this collection (indexed by the cookie name).
+     *
+     * @psalm-var array<string, string>
+     */
+    private array $cookies;
+
+    public function __construct(RequestProviderInterface $requestProvider)
+    {
+        /** @psalm-var array<string, string> */
+        $this->cookies = $requestProvider->get()->getCookieParams();
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->cookies[$name] ?? null;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->cookies[$name]);
+    }
+}

--- a/tests/RequestCookiesTest.php
+++ b/tests/RequestCookiesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\RequestProvider\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\ContainerConfig;
+use Yiisoft\RequestProvider\RequestCookies;
+use Yiisoft\RequestProvider\RequestProviderInterface;
+
+use function dirname;
+
+final class RequestCookiesTest extends TestCase
+{
+
+    public function testRequestCookiesGet(): void
+    {
+        $requestCoockies = $this->getRequestCookies();
+
+        $this->assertSame('value', $requestCoockies->get('test'));
+    }
+
+    public function testRequestCookiesHas():void
+    {
+        $requestCoockies = $this->getRequestCookies();
+
+        $this->assertTrue($requestCoockies->has('test'));
+
+        $this->assertFalse($requestCoockies->has('value'));
+    }
+
+    private function getRequestCookies(): RequestCookies
+    {
+        $container = $this->createContainer();
+        $requestProvider = $container->get(RequestProviderInterface::class);
+        $serverRequestMock = $this->createMock(ServerRequestInterface::class);
+        $serverRequestMock->method('getCookieParams')->willReturn([
+            'test' => 'value',
+        ]);
+        $requestProvider->set($serverRequestMock);
+
+        /** @var RequestCookies $requestCoockies */
+        return $container->get(RequestCookies::class);
+    }
+
+    private function createContainer(): Container
+    {
+        return new Container(
+            ContainerConfig::create()->withDefinitions($this->getContainerDefinitions())
+        );
+    }
+
+    private function getContainerDefinitions(): array
+    {
+        return require dirname(__DIR__) . '/config/di-web.php';
+    }
+}

--- a/tests/RequestCookiesTest.php
+++ b/tests/RequestCookiesTest.php
@@ -13,32 +13,30 @@ final class RequestCookiesTest extends TestCase
 {
     public function testGet(): void
     {
-        $requestCoockie = $this->getRequestCookies();
+        $requestCookies = $this->createRequestCookies(['test' => 'value']);
 
-        $this->assertSame('value', $requestCoockie->get('test'));
+        $this->assertSame('value', $requestCookies->get('test'));
     }
 
     public function testHas(): void
     {
-        $requestCoockie = $this->getRequestCookies();
+        $requestCookies = $this->createRequestCookies(['test' => 'value']);
 
-        $this->assertTrue($requestCoockie->has('test'));
-
-        $this->assertFalse($requestCoockie->has('value'));
+        $this->assertTrue($requestCookies->has('test'));
+        $this->assertFalse($requestCookies->has('non-exist'));
     }
 
-    private function getRequestCookies(): RequestCookies
+    private function createRequestCookies(array $cookies = []): RequestCookies
     {
         /** @var ServerRequestInterface $serverRequestMock */
         $serverRequestMock = $this->createMock(ServerRequestInterface::class);
-        $serverRequestMock->method('getCookieParams')->willReturn([
-            'test' => 'value',
-        ]);
+        $serverRequestMock
+            ->method('getCookieParams')
+            ->willReturn($cookies);
 
         /** @var RequestProviderInterface $requestProvider */
         $requestProvider = $this->createMock(RequestProviderInterface::class);
         $requestProvider->method('get')->willReturn($serverRequestMock);
-
 
         return new RequestCookies($requestProvider);
     }

--- a/tests/RequestCookiesTest.php
+++ b/tests/RequestCookiesTest.php
@@ -23,7 +23,7 @@ final class RequestCookiesTest extends TestCase
         $this->assertSame('value', $requestCoockies->get('test'));
     }
 
-    public function testRequestCookiesHas():void
+    public function testRequestCookiesHas(): void
     {
         $requestCoockies = $this->getRequestCookies();
 

--- a/tests/RequestCookiesTest.php
+++ b/tests/RequestCookiesTest.php
@@ -6,54 +6,40 @@ namespace Yiisoft\RequestProvider\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
-use Yiisoft\Di\Container;
-use Yiisoft\Di\ContainerConfig;
 use Yiisoft\RequestProvider\RequestCookies;
 use Yiisoft\RequestProvider\RequestProviderInterface;
 
-use function dirname;
-
 final class RequestCookiesTest extends TestCase
 {
-    public function testRequestCookiesGet(): void
+    public function testGet(): void
     {
-        $requestCoockies = $this->getRequestCookies();
+        $requestCoockie = $this->getRequestCookies();
 
-        $this->assertSame('value', $requestCoockies->get('test'));
+        $this->assertSame('value', $requestCoockie->get('test'));
     }
 
-    public function testRequestCookiesHas(): void
+    public function testHas(): void
     {
-        $requestCoockies = $this->getRequestCookies();
+        $requestCoockie = $this->getRequestCookies();
 
-        $this->assertTrue($requestCoockies->has('test'));
+        $this->assertTrue($requestCoockie->has('test'));
 
-        $this->assertFalse($requestCoockies->has('value'));
+        $this->assertFalse($requestCoockie->has('value'));
     }
 
     private function getRequestCookies(): RequestCookies
     {
-        $container = $this->createContainer();
-        $requestProvider = $container->get(RequestProviderInterface::class);
+        /** @var ServerRequestInterface $serverRequestMock */
         $serverRequestMock = $this->createMock(ServerRequestInterface::class);
         $serverRequestMock->method('getCookieParams')->willReturn([
             'test' => 'value',
         ]);
-        $requestProvider->set($serverRequestMock);
 
-        /** @var RequestCookies $requestCoockies */
-        return $container->get(RequestCookies::class);
-    }
+        /** @var RequestProviderInterface $requestProvider */
+        $requestProvider = $this->createMock(RequestProviderInterface::class);
+        $requestProvider->method('get')->willReturn($serverRequestMock);
 
-    private function createContainer(): Container
-    {
-        return new Container(
-            ContainerConfig::create()->withDefinitions($this->getContainerDefinitions())
-        );
-    }
 
-    private function getContainerDefinitions(): array
-    {
-        return require dirname(__DIR__) . '/config/di-web.php';
+        return new RequestCookies($requestProvider);
     }
 }

--- a/tests/RequestCookiesTest.php
+++ b/tests/RequestCookiesTest.php
@@ -15,7 +15,6 @@ use function dirname;
 
 final class RequestCookiesTest extends TestCase
 {
-
     public function testRequestCookiesGet(): void
     {
         $requestCoockies = $this->getRequestCookies();


### PR DESCRIPTION
- Created the RequestCookies class to manage cookies.
- It gets cookies from a RequestProviderInterface.
- Added methods to retrieve a cookie by name and check if a cookie exists.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
