### PR TITLE
Add `RequestCookieProvider`, mark `RequestCookies` as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.1 under development
 
 - Enh #17: Get request from provider into `RequestCookies` every time `get()` and `has()` methods are called (@vjik)
+- Chg #18: Add `RequestCookieProvider` instead of `RequestCookies`, which is marked as deprecated (@vjik)
 
 ## 1.1.0 October 28, 2024
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ final class MyService
 }
 ```
 
-### Request cookies collection
+### Request cookies provider
 
 You can work with cookies as follows:
 
@@ -62,7 +62,7 @@ You can work with cookies as follows:
 class MyClass
 {
   public function __construct(
-    private \Yiisoft\RequestProvider\RequestCookies $cookies
+    private \Yiisoft\RequestProvider\RequestCookieProvider $cookies
   ) {}
   
   public function go(): void

--- a/src/RequestCookieProvider.php
+++ b/src/RequestCookieProvider.php
@@ -6,10 +6,7 @@ namespace Yiisoft\RequestProvider;
 
 use function array_key_exists;
 
-/**
- * @deprecated Use {@see RequestCookieProvider} instead.
- */
-final class RequestCookies
+final class RequestCookieProvider
 {
     public function __construct(
         private readonly RequestProviderInterface $requestProvider,

--- a/tests/RequestCookieProviderTest.php
+++ b/tests/RequestCookieProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Yiisoft\RequestProvider\RequestCookieProvider;
+use Yiisoft\RequestProvider\RequestProvider;
+
+final class RequestCookieProviderTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $requestCookieProvider = $this->createRequestCookieProvider(['test' => 'value']);
+
+        $this->assertSame('value', $requestCookieProvider->get('test'));
+    }
+
+    public function testHas(): void
+    {
+        $requestCookieProvider = $this->createRequestCookieProvider(['test' => 'value']);
+
+        $this->assertTrue($requestCookieProvider->has('test'));
+        $this->assertFalse($requestCookieProvider->has('non-exist'));
+    }
+
+    public function testWithChangesInRequest(): void
+    {
+        $requestA = $this->createRequest(['test' => 'a']);
+        $requestB = $this->createRequest(['test' => 'b', 'city' => 'Voronezh']);
+
+        $requestProvider = new RequestProvider();
+        $requestProvider->set($requestA);
+
+        $requestCookieProvider = new RequestCookieProvider($requestProvider);
+
+        $this->assertSame('a', $requestCookieProvider->get('test'));
+        $this->assertFalse($requestCookieProvider->has('city'));
+
+        $requestProvider->set($requestB);
+
+        $this->assertSame('b', $requestCookieProvider->get('test'));
+        $this->assertTrue($requestCookieProvider->has('city'));
+    }
+
+    private function createRequestCookieProvider(array $cookies = []): RequestCookieProvider
+    {
+        $request = $this->createRequest($cookies);
+
+        $requestProvider = new RequestProvider();
+        $requestProvider->set($request);
+
+        return new RequestCookieProvider($requestProvider);
+    }
+
+    private function createRequest(array $cookies = []): ServerRequestInterface
+    {
+        /** @var ServerRequestInterface $request */
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->method('getCookieParams')
+            ->willReturn($cookies);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #16 
